### PR TITLE
Move control mixin to top-level

### DIFF
--- a/sass/partials/_mixins.scss
+++ b/sass/partials/_mixins.scss
@@ -4,6 +4,15 @@
   justify-content: center;
 }
 
+@mixin control($playBtnWidth, $fontSize, $textIndent) {
+  width: $playBtnWidth;
+  height: $playBtnWidth;
+  line-height: $playBtnWidth;
+  font-size: $fontSize;
+  text-indent: $textIndent;
+  left: calc(50% - #{$playBtnWidth/2});
+}
+
 @mixin artist-album-wrapper() {
   justify-content: space-between;
   flex-wrap: wrap;
@@ -75,15 +84,6 @@
       width: 100%;
       padding-top: 100%;
       position: relative;
-
-      @mixin control($playBtnWidth, $fontSize, $textIndent) {
-        width: $playBtnWidth;
-        height: $playBtnWidth;
-        line-height: $playBtnWidth;
-        font-size: $fontSize;
-        text-indent: $textIndent;
-        left: calc(50% - #{$playBtnWidth/2});
-      }
 
       .control {
         .as-list & {


### PR DESCRIPTION
This PR is related to [phanan/koe#748](https://github.com/phanan/koel/issues/748), more precisely to the following error:

```bash
...

$ cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js
 95% emitting ERROR  Failed to compile with 47 errors01:33:30

 error  in ./resources/assets/js/components/main-wrapper/main-content/artist.vue

Module build failed:
      @mixin control($playBtnWidth, $fontSize, $textIndent) {
            ^
      Mixins may not be defined within control directives or other mixins.
      in /var/www/koel/resources/assets/sass/partials/_mixins.scss (line 79, column 14)

 @ ./node_modules/vue-style-loader!./node_modules/css-loader!./node_modules/vue-loader/lib/style-compiler?{"vue":true,"id":"data-v-1ce16e40","scoped":true,"hasInlineConfig":true}!./node_modules/sass-loader/lib/loader.js!./node_modules/vue-loader/lib/selector.js?type=styles&index=0!./resources/assets/js/components/main-wrapper/main-content/artist.vue 4:14-378
 @ ./resources/assets/js/components/main-wrapper/main-content/artist.vue
 @ ./node_modules/babel-loader/lib?{"cacheDirectory":true,"presets":[["es2015",{"modules":false}]]}!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./resources/assets/js/components/main-wrapper/main-content/index.vue
 @ ./resources/assets/js/components/main-wrapper/main-content/index.vue
 @ ./node_modules/babel-loader/lib?{"cacheDirectory":true,"presets":[["es2015",{"modules":false}]]}!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./resources/assets/js/components/main-wrapper/index.vue
 @ ./resources/assets/js/components/main-wrapper/index.vue
 @ ./node_modules/babel-loader/lib?{"cacheDirectory":true,"presets":[["es2015",{"modules":false}]]}!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./resources/assets/js/app.vue
 @ ./resources/assets/js/app.vue
 @ ./resources/assets/js/app.js
 @ multi ./resources/assets/js/app.js ./resources/assets/sass/app.scss ./resources/assets/sass/remote.scss

 error  in ./resources/assets/sass/app.scss

...
```

After this change, the compilation worked with the following versions used:
- Node v10.0.0
- npm v6.1.0
- koel latest commit ([1475eba](https://github.com/phanan/koel/commit/1475ebaddfc4bedd8398c13e34d2c5222518acf2))

```bash
$ npm run production

> koel@ production /home/axel/Schreibtisch/Projekte/koel
> cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js

 95% emitting                                                                           

 DONE  Compiled successfully in 24013ms                                                14:56:00

                                                           Asset       Size  Chunks                    Chunk Names
                                            img/artists/.gitkeep    0 bytes          [emitted]         
  fonts/fontawesome-webfont.eot?674f50d287a8c48dc19ba404d20fe713     166 kB          [emitted]         
 fonts/fontawesome-webfont.woff?fee66e712a8a08eef5805a46892932ad      98 kB          [emitted]         
  fonts/fontawesome-webfont.ttf?b06871f281fee6b241d60582ae9369b9     166 kB          [emitted]         
  fonts/fontawesome-webfont.svg?912ec66d7572ff821749319396470bde     444 kB          [emitted]  [big]  
                 fonts/logo.svg?8a2f5cec8d12d85f91ae82ef106ecb28    5.19 kB          [emitted]         
                images/bars.gif?23fc89ec29a37a769bef1b4444abceb2    33.2 kB          [emitted]         
                                 /js/app.7c665f48e54814b06b22.js     825 kB       0  [emitted]  [big]  /js/app
                          /js/remote/app.585b6e9f2cca4fa68df5.js     547 kB       1  [emitted]  [big]  /js/remote/app
                               /css/app.37d11a0152d39cb4902e.css    18.4 kB       0  [emitted]         /js/app
                            /css/remote.37d11a0152d39cb4902e.css   40 bytes       0  [emitted]         /js/app
                                               mix-manifest.json  234 bytes          [emitted]         
                                                    img/bars.gif    33.2 kB          [emitted]         
                                                    img/logo.svg    5.19 kB          [emitted]         
fonts/fontawesome-webfont.woff2?af7ae505a9eed503f8b8e6982036873e    77.2 kB          [emitted]         
                                                 img/favicon.ico    4.29 kB          [emitted]         
                                                  img/itunes.svg    1.54 kB          [emitted]         
                                               img/tile-wide.png    3.25 kB          [emitted]         
                                                    img/tile.png    6.47 kB          [emitted]         
                                    img/covers/unknown-album.png    11.5 kB          [emitted]         
                                                    img/icon.png    10.8 kB          [emitted]         
                                                    img/logo.png    9.28 kB          [emitted]         
                                   fonts/fontawesome-webfont.eot     166 kB          [emitted]         
                                   fonts/fontawesome-webfont.svg     444 kB          [emitted]  [big]  
                                   fonts/fontawesome-webfont.ttf     166 kB          [emitted]         
                                  fonts/fontawesome-webfont.woff      98 kB          [emitted]         
                                 fonts/fontawesome-webfont.woff2    77.2 kB          [emitted]         
                                           fonts/FontAwesome.otf     135 kB          [emitted]         

```