### PR TITLE
Add buttons to play in current order

### DIFF
--- a/js/components/screens/playlist.vue
+++ b/js/components/screens/playlist.vue
@@ -20,7 +20,9 @@
 
         <song-list-controls
           v-show="!isPhone || showingControls"
+          @playAll="playAll"
           @shuffleAll="shuffleAll"
+          @playSelected="playSelected"
           @shuffleSelected="shuffleSelected"
           @deletePlaylist="confirmDelete"
           :config="songListControlConfig"
@@ -77,12 +79,20 @@ export default {
   },
 
   methods: {
+    playAll () {
+      playback.queueAndPlay(this.playlist.songs, false)
+    },
+
     /**
      * Shuffle the songs in the current playlist.
      * Overriding the mixin.
      */
     shuffleAll () {
       playback.queueAndPlay(this.playlist.songs, true /* shuffled */)
+    },
+
+    playSelected () {
+      playback.queueAndPlay(this.selectedSongs, false)
     },
 
     confirmDelete () {

--- a/js/components/song/list-controls.vue
+++ b/js/components/song/list-controls.vue
@@ -1,9 +1,21 @@
 <template>
   <div class="buttons song-list-controls">
+    <button class="btn btn-green btn-play-all"
+      @click.prevent="play"
+      v-if="selectedSongs.length < 2">
+      <i class="fa fa-play"></i> All
+    </button>
+
     <button class="btn btn-orange btn-shuffle-all"
       @click.prevent="shuffle"
       v-if="fullConfig.shuffle && selectedSongs.length < 2">
       <i class="fa fa-random"></i> All
+    </button>
+
+    <button class="btn btn-green btn-play-selected"
+      @click.prevent="playSelected"
+      v-if="selectedSongs.length > 1">
+      <i class="fa fa-play"></i> Selected
     </button>
 
     <button class="btn btn-orange btn-shuffle-selected"
@@ -83,8 +95,16 @@ export default {
   },
 
   methods: {
+    play () {
+      this.$emit('playAll')
+    },
+
     shuffle () {
       this.$emit('shuffleAll')
+    },
+
+    playSelected () {
+      this.$emit('playSelected')
     },
 
     shuffleSelected () {


### PR DESCRIPTION
As commented in https://github.com/phanan/koel/issues/827 , album / playlist screens could use a button for playing in current order:

![all](https://user-images.githubusercontent.com/75626/50734267-55797080-1162-11e9-8b51-5b3a4bc44061.png)
![all-selected](https://user-images.githubusercontent.com/75626/50734268-57433400-1162-11e9-92d4-1b22d1d28dc3.png)
