### PR TITLE
add h/l as keys for rewind/forward current song

### DIFF
--- a/js/components/utils/hotkeys.vue
+++ b/js/components/utils/hotkeys.vue
@@ -3,8 +3,10 @@
     @keydown.space="togglePlayback"
     @keydown.j = "playNext"
     @keydown.k = "playPrev"
-    @keydown.f = "search"
-    @keydown.l = "toggleLike"
+    @keydown.h = "playRewind"
+    @keydown.l = "playForward"
+    @keydown.s = "search"
+    @keydown.f = "toggleLike"
     @keydown.mediaPrev = "playPrev"
     @keydown.mediaNext = "playNext"
     @keydown.mediaToggle = "togglePlayback"
@@ -29,8 +31,10 @@ Vue.config.keyCodes = {
   a: 65,
   j: 74,
   k: 75,
-  f: 70,
+  h: 72,
   l: 76,
+  s: 83,
+  f: 70,
   mediaNext: 176,
   mediaPrev: 177,
   mediaToggle: 179
@@ -104,6 +108,34 @@ export default {
       }
 
       playback.playNext()
+      e.preventDefault()
+    },
+
+    /**
+     * Rewind current song N seconds
+     *
+     * @param {Object} e The keydown event
+     */
+    playRewind: e => {
+      if ($.is(e.target, 'input,textarea')) {
+        return true
+      }
+
+      playback.playRewind(10)
+      e.preventDefault()
+    },
+
+    /**
+     * Forward current song N seconds
+     *
+     * @param {Object} e The keydown event
+     */
+    playForward: e => {
+      if ($.is(e.target, 'input,textarea')) {
+        return true
+      }
+
+      playback.playForward(10)
       e.preventDefault()
     },
 

--- a/js/services/playback.js
+++ b/js/services/playback.js
@@ -278,6 +278,24 @@ export const playback = {
   },
 
   /**
+   * Rewind current song
+   *
+   * @param {Number} seconds   0-999
+   */
+  playRewind (seconds) {
+    this.player.rewind(seconds)
+  },
+
+  /**
+   * Forward current song
+   *
+   * @param {Number} seconds   0-999
+   */
+  playForward (seconds) {
+    this.player.forward(seconds)
+  },
+
+  /**
    * @param {Number}     volume   0-10
    * @param {Boolean=true}   persist  Whether the volume should be saved into local storage
    */


### PR DESCRIPTION
When discovering new music it's often useful to fast forward / rewind the current song, this commit adds such hotkeys `h/l`, so koel emulates `vim` movement `j/k/h/l`, probably it could be even better if koel could read from a configuration variable such keys so anyone can specify its favourite shotcuts, however I'm not really familiar with vau therefore I'm leaving such exercise for the future.

Also, while testing this functionality I found koel setups a `canplay` event listener which fires in `playNext`, `playPrev`, and in seek / fastforwarding operations, as Koel [limits its API to 60 request per minute](https://github.com/phanan/koel/blob/master/app/Http/Kernel.php#L43) I found soon than leaving such event generator quickly freeze the interface, my temporal solution was to disable throttle, I'm still looking for a more general solution.