### PR TITLE
Track number ordering

### DIFF
--- a/js/components/song/list.vue
+++ b/js/components/song/list.vue
@@ -156,6 +156,21 @@ export default {
       })
     },
 
+    defaultSort () {
+      // there are certain cirscumstances where sorting is simply disallowed, e.g. in Queue
+      if (this.sortable === false) {
+        return
+      }
+
+      // if this is an album's song list, default to sorting by track number
+      // and additionally sort by disc number
+      if (this.type === 'album') {
+        this.sortKey = ['song.disc', 'song.track']
+      }
+      this.order = 1
+      this.songRows = orderBy(this.songRows, this.sortKey, this.order)
+    },
+
     /**
      * @param  {String} key The sort key. Can be 'title', 'album', 'artist', or 'length'
      */
@@ -170,19 +185,8 @@ export default {
         this.order *= -1
       }
 
-      // if this is an album's song list, default to sorting by track number
-      // and additionally sort by disc number
-      if (this.type === 'album') {
-        this.sortKey = this.sortKey ? this.sortKey : ['song.track']
-        this.sortKey = [].concat(this.sortKey)
-        if (!this.sortKey.includes('song.disc')) {
-          this.sortKey.push('song.disc')
-        }
-      }
-
       this.sortingByAlbum = this.sortKey[0] === 'song.album.name'
       this.sortingByArtist = this.sortKey[0] === 'song.album.artist.name'
-
       this.songRows = orderBy(this.songRows, this.sortKey, this.order)
     },
 
@@ -394,6 +398,7 @@ export default {
   mounted () {
     if (this.items) {
       this.render()
+      this.defaultSort()
     }
   },
 

--- a/js/tests/components/song/list.spec.js
+++ b/js/tests/components/song/list.spec.js
@@ -6,7 +6,7 @@ import { event } from '@/utils'
 import { songStore, queueStore } from '@/stores'
 import { playback } from '@/services'
 import { mock } from '@/tests/__helpers__'
-import { shallowMount } from "@vue/test-utils"
+import { shallowMount } from '@vue/test-utils'
 import * as filters from '@/utils/filters.js'
 
 describe('components/song/list', () => {
@@ -145,7 +145,7 @@ describe('components/song/list', () => {
       orderBy = jest.spyOn(filters, "orderBy")
     })
 
-    it(`when sorting is disallowed, it will not sort`, () => {
+    it(`does not sort when sorting is disallowed`, () => {
       shallowMount(Component, {
         propsData: {
           items: songs,
@@ -168,8 +168,7 @@ describe('components/song/list', () => {
       expect(orderBy).toHaveBeenCalledWith(expect.any(Array), "", 1)
     })
 
-    it(`when it's an album's song list,
-      it will sort songs by track number and then disc number`, () => {
+    it('sorts songs by track and disc number in album song list', () => {
       shallowMount(Component, {
         propsData: {
           items: songs,
@@ -191,7 +190,7 @@ describe('components/song/list', () => {
       orderBy = jest.spyOn(filters, "orderBy")
     })
 
-    it(`when sorting is disallowed, it will do nothing`, () => {
+    it(`does not sort when sorting is disallowed`, () => {
       const wrapper = shallowMount(Component, {
         propsData: {
           items: songs,
@@ -205,7 +204,7 @@ describe('components/song/list', () => {
       expect(orderBy).not.toHaveBeenCalled()
     })
 
-    it(`will sort song rows by data's sortKey and invert order`, () => {
+    it(`sorts song rows by data's sortKey and inverts order`, () => {
       const wrapper = shallowMount(Component, {
         propsData: {
           items: songs,
@@ -219,7 +218,7 @@ describe('components/song/list', () => {
       expect(orderBy).toHaveBeenCalledWith(expect.any(Array), "song.track", 1)
     })
 
-    it(`will toggle sortingByAlbum if sortKey's first part is 'song.album.name'`, () => {
+    it(`toggles sortingByAlbum if sortKey's first part is 'song.album.name'`, () => {
       const wrapper = shallowMount(Component, {
         propsData: {
           items: songs,
@@ -233,7 +232,7 @@ describe('components/song/list', () => {
       expect(wrapper.vm.sortingByAlbum).toBe(true)
     })
 
-    it(`will toggle sortingByArtist if sortKey's first part is 'song.album.artist.name'`, () => {
+    it(`toggles sortingByArtist if sortKey's first part is 'song.album.artist.name'`, () => {
       const wrapper = shallowMount(Component, {
         propsData: {
           items: songs,
@@ -249,7 +248,7 @@ describe('components/song/list', () => {
       expect(wrapper.vm.sortingByArtist).toBe(true)
     })
 
-    it(`when called with a key parameter, it will set it as sortKey and invert order`, () => {
+    it(`sets the key parameter as sortKey and inverts order`, () => {
       const wrapper = shallowMount(Component, {
         propsData: {
           items: songs,

--- a/js/tests/utils/filters.spec.js
+++ b/js/tests/utils/filters.spec.js
@@ -1,0 +1,123 @@
+import { orderBy } from "@/utils"
+
+describe(`utils/filters`, () => {
+  describe(`orderBy`, () => {
+    it(`when no sortKey is provided, it will return the given array as-is`, () => {
+      const initial = [20, 10, 30]
+      const result = orderBy(initial, "", 1)
+      expect(result).toBe(initial)
+    })
+
+    describe(`when the given array holds numbers`, () => {
+      it(`will sort them by order without mutating the given array`, () => {
+        const initial = [20, 10, 30]
+        const result = orderBy(initial, true, 1)
+        expect(result).toEqual([10, 20, 30])
+        expect(result).not.toBe(initial)
+      })
+
+      it(`will sort them by reverse order when "reverse" is negative`, () => {
+        const result = orderBy([20, 10, 30], true, -1)
+        expect(result).toEqual([30, 20, 10])
+      })
+    })
+
+    describe(`when the given array holds strings`, () => {
+      it(`will sort them after lower-casing`, () => {
+        const result = orderBy(["Alpha", "albert", "Bravo"], true, 1)
+        expect(result).toEqual(["albert", "Alpha", "Bravo"])
+      })
+    })
+
+    describe(`given an array of song wrappers`, () => {
+      it(`and given sortKey is "song.title",
+        it will sort the song wrappers by their title`, () => {
+        const alpha_song = { song: { title: "Alpha" }}
+        const bravo_song = { song: { title: "Bravo" }}
+        const charlie_song = { song: { title: "Charlie" }}
+
+        const result = orderBy(
+          [alpha_song, charlie_song, bravo_song],
+          "song.title",
+          1
+        )
+        expect(result).toEqual([alpha_song, bravo_song, charlie_song])
+      })
+
+      it(`and given sortKey is "song.album.name",
+        it will sort the song wrappers by their album name`, () => {
+        const alpha_song = { song: { album: { name: "Alpha" }}}
+        const bravo_song = { song: { album: { name: "Bravo" }}}
+        const charlie_song = { song: { album: { name: "Charlie" }}}
+
+        const result = orderBy(
+          [alpha_song, charlie_song, bravo_song],
+          "song.album.name",
+          1
+        )
+        expect(result).toEqual([alpha_song, bravo_song, charlie_song])
+      })
+
+      it(`and given sortKey is "song.album.artist.name",
+        it will sort the song wrappers by their artist name`, () => {
+        const alpha_song = { song: { album: { artist: { name: "Alpha" }}}}
+        const bravo_song = { song: { album: { artist: { name: "Bravo" }}}}
+        const charlie_song = {
+          song: { album: { artist: { name: "Charlie" }}}
+        }
+
+        const result = orderBy(
+          [alpha_song, charlie_song, bravo_song],
+          "song.album.artist.name",
+          1
+        )
+        expect(result).toEqual([alpha_song, bravo_song, charlie_song])
+      })
+
+      it(`and given sortKey is ["song.track", "song.disc"],
+        it will sort the song wrappers first by their track number,
+        then by their disc number`, () => {
+        const alpha_song = { song: { track: 1, disc: 1 }}
+        const bravo_song = { song: { track: 1, disc: 2 }}
+        const charlie_song = { song: { track: 2, disc: 1 }}
+
+        const result = orderBy(
+          [alpha_song, charlie_song, bravo_song],
+          ["song.track", "song.disc"],
+          1
+        )
+        expect(result).toEqual([alpha_song, bravo_song, charlie_song])
+      })
+
+      it(`and given sortKey is ["song.disc", "song.track"],
+        it will sort the song wrappers first by their disc number,
+        then by their track number`, () => {
+        const alpha_song = { song: { track: 1, disc: 1 }}
+        const bravo_song = { song: { track: 2, disc: 1 }}
+        const charlie_song = { song: { track: 2, disc: 1 }}
+
+        const result = orderBy(
+          [alpha_song, charlie_song, bravo_song],
+          ["song.disc", "song.track"],
+          1
+        )
+        expect(result).toEqual([alpha_song, bravo_song, charlie_song])
+      })
+
+      it(`and given sortKey is ["song.album.name", "song.track"]
+        it will sort the song wrappers first by their album name,
+        then by their track number`, () => {
+        const alpha_song = { song: { album: { name: "Alpha" }, track: 1 }}
+        const bravo_song = { song: { album: { name: "Alpha" }, track: 2 }}
+        const charlie_song = { song: { album: { name: "Bravo" }, track: 1 }}
+
+        const result = orderBy(
+          [alpha_song, charlie_song, bravo_song],
+          ["song.album.name", "song.track"],
+          1
+        )
+        expect(result).toEqual([alpha_song, bravo_song, charlie_song])
+      })
+    })
+  })
+})

--- a/js/utils/filters.js
+++ b/js/utils/filters.js
@@ -1,4 +1,4 @@
-import { isObject, isNumber, get } from "lodash"
+import { isObject, isNumber, get } from 'lodash'
 
 export const orderBy = (arr, sortKey, reverse) => {
   if (!sortKey) {

--- a/js/utils/filters.js
+++ b/js/utils/filters.js
@@ -1,36 +1,21 @@
-import { isObject, isNumber, get } from 'lodash'
+import { isObject, isNumber, get } from "lodash"
 
 export const orderBy = (arr, sortKey, reverse) => {
   if (!sortKey) {
     return arr
   }
 
-  const order = (reverse && reverse < 0) ? -1 : 1
-
-  const compareRecordsByKey = (a, b, key) => {
-    let aKey = isObject(a) ? get(a, key) : a
-    let bKey = isObject(b) ? get(b, key) : b
-
-    if (isNumber(aKey) && isNumber(bKey)) {
-      return aKey === bKey ? 0 : aKey > bKey
-    }
-
-    aKey = aKey === undefined ? aKey : `${aKey}`.toLowerCase()
-    bKey = bKey === undefined ? bKey : `${bKey}`.toLowerCase()
-
-    return aKey === bKey ? 0 : aKey > bKey
-  }
+  const order = reverse && reverse < 0 ? -1 : 1
 
   // sort on a copy to avoid mutating original array
   return arr.slice().sort((a, b) => {
-    if (sortKey.constructor === Array) {
-      let diff = 0
-      for (let i = 0; i < sortKey.length; i++) {
-        diff = compareRecordsByKey(a, b, sortKey[i])
-        if (diff !== 0) {
-          break
+    if (sortKey instanceof Array) {
+      const diff = sortKey.reduce((accumulator, sort_by) => {
+        if (accumulator === 0) {
+          accumulator = compareRecordsByKey(a, b, sort_by)
         }
-      }
+        return accumulator
+      }, 0)
 
       return diff === 0 ? 0 : diff === true ? order : -order
     }
@@ -39,15 +24,35 @@ export const orderBy = (arr, sortKey, reverse) => {
     b = isObject(b) ? get(b, sortKey) : b
 
     if (isNumber(a) && isNumber(b)) {
-      return a === b ? 0 : a > b ? order : -order
+      return compareAscOrDesc(a, b, order)
     }
 
-    a = a === undefined ? a : a.toLowerCase()
-    b = b === undefined ? b : b.toLowerCase()
+    const lowercase_a = lowerCaseIfDefined(a)
+    const lowercase_b = lowerCaseIfDefined(b)
 
-    return a === b ? 0 : a > b ? order : -order
+    return compareAscOrDesc(lowercase_a, lowercase_b, order)
   })
 }
+
+const compareRecordsByKey = (a, b, key) => {
+  const aKey = isObject(a) ? get(a, key) : a
+  const bKey = isObject(b) ? get(b, key) : b
+
+  if (isNumber(aKey) && isNumber(bKey)) {
+    return aKey === bKey ? 0 : aKey > bKey
+  }
+
+  const lowercase_a = lowerCaseIfDefined(aKey)
+  const lowercase_b = lowerCaseIfDefined(bKey)
+
+  return lowercase_a === lowercase_b ? 0 : lowercase_a > lowercase_b
+}
+
+const compareAscOrDesc = (a, b, order) =>
+  a === b ? 0 : a > b ? order : -order
+
+const lowerCaseIfDefined = uppercase =>
+  uppercase === undefined ? uppercase : uppercase.toString().toLowerCase()
 
 export const limitBy = (arr, n, offset = 0) => arr.slice(offset, offset + n)
 


### PR DESCRIPTION
Related to phanan/koel#1089

Hi, this is my first pull request for koel !
The intent of this contribution is to order album song lists first by CD number, then by track number.

Help for testing:
- Given an album with tracks in 2 CDs
- When you browse that album, songs are ordered first by CD number, then by track number, so that the following order is followed:

1. CD 1. Track 1
2. CD 1. Track 2
3. CD 2. Track 1

- After browsing, when you sort again by track number (by clicking on the table header), the ordering still does not consider Disc number. This calls for a deeper refactoring and will need a separate contribution.

Note to reviewer:
I have tried to add unit-tests for everything I've touched. Please let me know if more need to be added. I am not used at all to the "no-semicolon" style so apologies if some slipped through, I intended to `eslint fix` them all. Also I am used to a coding style where variables are in snake_case and functions are in camelCase, let me know if that is a problem and I'll adapt.

I do intend on contributing to koel some more and hope to be able to in the future. I can't promise anything on the frequency of those contributions, as family life and day job do not leave much time...
I have experience working on PHP / VueJS codebases and I have a couple of ideas to make koel even better.

Looking forward to your feedback on this :)