### PR TITLE
Update Koel's GitHub URL

### DIFF
--- a/js/components/meta/about-dialog.vue
+++ b/js/components/meta/about-dialog.vue
@@ -20,7 +20,7 @@
       <p class="author">
         Made with ❤️ by <a href="https://github.com/phanan" target="_blank">Phan An</a>
         and quite a few <a href="https://github.com/koel/core/graphs/contributors" target="_blank">awesome</a>
-        <a href="https://github.com/phanan/koel/graphs/contributors" target="_blank">contributors</a>.
+        <a href="https://github.com/phanan/koel/koel/contributors" target="_blank">contributors</a>.
       </p>
 
       <p class="demo-credits" v-if="demo">


### PR DESCRIPTION
Koel has been moved from `https://github.com/phanan/koel/` to `https://github.com/koel/koel/graphs/contributors` this PR updates the following URL:
`https://github.com/koel/koel/graphs/contributors`