### PR TITLE
Set default Gravatar to Mystery Person

### DIFF
--- a/js/__tests__/stores/user.spec.ts
+++ b/js/__tests__/stores/user.spec.ts
@@ -30,11 +30,11 @@ describe('stores/user', () => {
 
   it('sets the current user’s avatar', () => {
     userStore.setAvatar()
-    expect(userStore.current.avatar).toBe('https://www.gravatar.com/avatar/b9611f1bba1aacbe6f5de5856695a202?s=256')
+    expect(userStore.current.avatar).toBe('https://www.gravatar.com/avatar/b9611f1bba1aacbe6f5de5856695a202?s=256&d=mp')
   })
 
   it('sets a user’s avatar', () => {
     userStore.setAvatar(users[1])
-    expect(users[1].avatar).toBe('https://www.gravatar.com/avatar/5024672cfe53f113b746e1923e373058?s=256')
+    expect(users[1].avatar).toBe('https://www.gravatar.com/avatar/5024672cfe53f113b746e1923e373058?s=256&d=mp')
   })
 })

--- a/js/stores/user.ts
+++ b/js/stores/user.ts
@@ -52,7 +52,7 @@ export const userStore = {
    */
   setAvatar (user?: User): void {
     user = user || this.current
-    Vue.set(user, 'avatar', `https://www.gravatar.com/avatar/${md5(user.email)}?s=256`)
+    Vue.set(user, 'avatar', `https://www.gravatar.com/avatar/${md5(user.email)}?s=256&d=mp`)
   },
 
   login: async (email: string, password: string): Promise<User> => {


### PR DESCRIPTION
Fixes #33

This PR adds `&d=mp` to change the default Gravatar from the Gravatar logo to the Mystery Person.

See: https://en.gravatar.com/site/implement/images/#default-image