### PR TITLE
Recognize the standard MIME type for uploaded FLAC audio

### DIFF
--- a/js/config/valid-media-mime-types.ts
+++ b/js/config/valid-media-mime-types.ts
@@ -1,4 +1,5 @@
 export const validMediaMimeTypes = [
+  'audio/flac',
   'audio/mp3',
   'audio/mpeg',
   'audio/ogg',


### PR DESCRIPTION
Before this change Koel only recognized the non-standard MIME type audio/x-flac, hence refusing to accept FLAC uploads on my system.

Similarly AAC audio goes by audio/aac, but since I have no files to test this against I opted not to touch the current definition.

Source: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#flac

~~NOTE: It appears even with this change, Koel returns 422 (unprocessable entity) upon trying to upload a FLAC file.~~ Added a server-side patch at https://github.com/koel/koel/pull/1290, using which FLAC uploads work just fine for me now 🥳